### PR TITLE
Update numpy seed value

### DIFF
--- a/train.py
+++ b/train.py
@@ -50,7 +50,7 @@ opt = parser.parse_args()
 
 def _worker_init_fn_():
     torch_seed = torch.initial_seed()
-    np_seed = torch_seed // 2**32-1
+    np_seed = torch_seed % 2**32-1
     random.seed(torch_seed)
     np.random.seed(np_seed)
 


### PR DESCRIPTION
The existing code creates very large seed values (greater than 32 bits), which causes numpy to truncate them to 32 bits, resulting in the same stream of random numbers for two different seeds. See error below:

`File "mtrand.pyx", line 246, in numpy.random.mtrand.RandomState.seed File "_mt19937.pyx", line 166, in numpy.random._mt19937.MT19937._legacy_seeding File "_mt19937.pyx", line 180, in numpy.random._mt19937.MT19937._legacy_seeding ValueError: Seed must be between 0 and 2**32 - 1`

This is reported in [numpy@6b1a120](https://github.com/numpy/numpy/commit/6b1a1205eac6fe5d162f16155d500765e8bca53c).

I fixed this by limiting the seed to 32 bits, like [here](https://github.com/GiulioRossetti/ndlib/issues/209).